### PR TITLE
format and misspelling

### DIFF
--- a/draft-bg-onions-update-network-service-models.md
+++ b/draft-bg-onions-update-network-service-models.md
@@ -80,65 +80,88 @@ Service and Network YANG data models {{?RFC8199}}{{?RFC8309}} such as the Layer 
 
 ## Enhancements to LxSM and LxNM
 
-Implementations of LxNM models in controllers required new functionalities which were not covered {{!RFC9182}} and {{!RFC9291}} to deploy the missing functions in the Operator services. This section compiles the functions that were reported by those implementations.
+Implementations of LxNM models in controllers required new functionalities which were not covered in {{!RFC9182}} and {{!RFC9291}} to deploy the missing functions in Operator services. This section compiles the functions that were reported by those implementations.
 
 ### L3NM Enhancements
 
-* BFD parametrization of static routes (Github issue #1):
-    +  The L3NM Yang data model allows to manage static routes in a VPN. That is, for a particular VPN service, new Pv4 and IPv6 static routes can be added, modified or deleted. The data model allows to specify wether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route it will need to decide a particular BFD configuration, typically from a pre-defined template. Operators required, for different services, to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify BFD intented configuration in the IPv4 and IPv6 static routes, including a required-min-rx-interval and multiplier.
+* BFD parametrization of static routes (**GitHub Issue #1**):  
+  + The L3NM YANG data model allows management of static routes in a VPN. That is, for a particular VPN service, new IPv4 and IPv6 static routes can be added, modified, or deleted. The data model allows specifying whether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route, it will need to decide a particular BFD configuration, typically from a predefined template. Operators require, for different services, the ability to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify intended BFD configuration in the IPv4 and IPv6 static routes, including `required-min-rx-interval` and `multiplier`.  
 
-* Management of VLAN 0 in tagged interfaces (Github issue #2): LxNM Yang models have a range defined for cvlan between 1 and 4094. VLAN 0 should also be supported and is used in deployments.
-* Missing BGP intended configuration blocks (position against Attachment Circuits) (Github issue #3).
-    + There are a set of BGP configuration blocks required to manage BGP based services which are present now in the AC-Model but not in the L3NM:
-        - BGP Peer group creation
-        - BGP Redistribution rules
-    + Missing pointer to ACL (also present in Github issue #3).
-        - ACL pointer to attach forwarding filter
-* SRv6 support for L3VPN (issue #15): SRv6-based BGP services including L3VPN, whose procedures are defined in {{?RFC9252}}
-* Improving Multicast Support:
-     + For L3VPN with multicast, one implementation has reported that Cisco MVPN augmentation were added to include various profiles ( ipmsi and spmsi ) . There is YANG module from IETF as of today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.
+* Management of VLAN 0 in tagged interfaces (**GitHub Issue #2**):  
+  LxNM YANG models have a range defined for CVLAN between 1 and 4094. VLAN 0 should also be supported, as it is used in deployments.  
+
+* Missing BGP intended configuration blocks (position against Attachment Circuits) (**GitHub Issue #3**):  
+  + There are BGP configuration blocks required to manage BGP-based services which are present in the AC-Model but not in the L3NM:  
+    - BGP Peer group creation  
+    - BGP Redistribution rules  
+  + Missing pointer to ACL (also present in **GitHub Issue #3**):  
+    - ACL pointer to attach forwarding filter  
+
+* SRv6 support for L3VPN (**GitHub Issue #15**):  
+  SRv6-based BGP services, including L3VPN, whose procedures are defined in {{?RFC9252}}.  
+
+* Improving Multicast Support:  
+  + For L3VPN with multicast, one implementation reported that Cisco MVPN augmentations were added to include various profiles (IPMSI and SPMSI). There is no YANG module from IETF today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.  
+
+* Extend guidance on how the network models can be used to operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework.  
 
 ### L2NM Enhancements
 
-* EVPN Remote and Local eth-tag (Github issue #6)
-* Explicity asign a RD at node leve (Github issue #7)
-   + In the model, a RD must be always asigned via profile at service level. It is useful to be able to set a explicit RD directly at nodel level overriding the value of the profile. This way, a common profile can be used for the whole services for use cases where only RD changes per node.
+* EVPN Remote and Local eth-tag (**GitHub Issue #6**)  
 
-* Add support for Flexible Cross-Connect (FXC) Service ({{?RFC9744}}) (Github issue #8)
-* Add explanatory text for EVPN multihoming using LAG (Github issue #9)
-* support for vlan-lists/vlan-ranges (Github issue #10)
-   + When defining a Layer 2 service, sometimes multiple VLANs are mapped into a given service. It would be good to support this in the L2NM encapsulation stanza. Examples are as follows:
-       - Typically used in single-tagged scenarios: vlan-id-list [ 200 210-219 222 234 240-249 ];
-       - Dual-tagged scenario, with s-vlan=430 and a list of c-vlans: vlan-tags outer 430 inner-list [ 200 210-219 222 234 240-249 ];
-* SRv6 support for L2VPN (issue #15)
-* Performance monitoring
-    + ITU-T Y.1731 performance monitoring in Ethernet based networks . L2NM itself (RFC 9291) doesn't natively include OAM specifics
+* Explicitly assign an RD at node level (**GitHub Issue #7**):  
+  + In the model, an RD must always be assigned via profile at service level. It is useful to be able to set an explicit RD directly at node level, overriding the profile value. This way, a common profile can be used for the whole service, with use cases where only the RD changes per node.  
+
+* Add support for Flexible Cross-Connect (FXC) Service ({{?RFC9744}}) (**GitHub Issue #8**)  
+
+* Add explanatory text for EVPN multihoming using LAG (**GitHub Issue #9**)  
+
+* Support for VLAN-lists/VLAN-ranges (**GitHub Issue #10**):  
+  + When defining a Layer 2 service, sometimes multiple VLANs are mapped into a given service. It would be good to support this in the L2NM encapsulation stanza. Examples are as follows:  
+    - Typically used in single-tagged scenarios: `vlan-id-list [200 210-219 222 234 240-249];`  
+    - Dual-tagged scenario, with s-vlan=430 and a list of c-vlans: `vlan-tags outer 430 inner-list [200 210-219 222 234 240-249];`  
+
+* SRv6 support for L2VPN (**GitHub Issue #15**)  
+
+* Performance monitoring:  
+  + ITU-T Y.1731 performance monitoring in Ethernet-based networks. L2NM itself ({{?RFC9291}}) does not natively include OAM specifics.  
+
+* Add EVI identifier to differentiate it from VPN-ID (**GitHub Issue #24**):  
+  Each EVI maps to a specific EVPN service (e.g., a Layer 2 VPN bridging a particular VLAN across the EVPN fabric).  
 
 ## New Functionalities Required to Fully Support Connectivity Services
 
-The realization of advance connectivity services requires, in addition to the configurations expressed in LxNM models:
-* Definition of Access Control lists and prefix Sets:
-    + Connectivity services often include mechanisms to filter forwarding packets. The LxNM models allow to include a 'forwarding-profile-identifier'. A forwarding profile refers to the policies that apply to the forwarding of packets conveyed within a VPN. Such policies may consist, for example, of applying Access Control Lists (ACLs). However, currently there is not an ACL network service model (even though a device level ACL model exists) that allows to manipulate such ACLs and sets when creating the service.
-    + ACLs and Prefix sets can be reused among services. Thus, they need to be handled at a network level, regardless of the actual service using them.
-* Definition of routing policies, including community sets, as path sets, etc:
-    + Advance connectivity services require the creation of complex policies. The LxNM models allows to indicate which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set a device models which could be used as a base for the network model.
-* Pre and post checks
-* Preparation of the interface. Prior to setting up .
+The realization of advanced connectivity services requires, in addition to the configurations expressed in LxNM models:
+
+* Definition of Access Control Lists (ACLs) and Prefix Sets:  
+  + Connectivity services often include mechanisms to filter forwarding packets. The LxNM models allow inclusion of a `forwarding-profile-identifier`. A forwarding profile refers to the policies that apply to the forwarding of packets conveyed within a VPN. Such policies may consist, for example, of applying ACLs. However, there is currently no ACL network service model (even though a device-level ACL model exists) that allows manipulation of such ACLs and sets when creating the service.  
+  + ACLs and Prefix sets can be reused among services. Thus, they need to be handled at a network level, regardless of the actual service using them.  
+
+* Definition of routing policies, including community sets, path sets, etc.:  
+  + Advanced connectivity services require the creation of complex policies. The LxNM models allow indicating which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set of device models which could be used as a base for the network model.  
+
+* Pre- and post-checks before and after deploying a service in the network.  
+
+* Preparation of the interface prior to setting up the service.  
+
+---
 
 ## Status of the Intended Network Service
 
-The Network Service Yang models represents an intent of the realization of service. A controller, after an instance of the network service yang intent has been created, will derive the necessary device level configurations and apply them to the necessary devices. However, the implementations reported a set of open issues which are related to the status. Those issues are not solved today and are left to implementation choices and solutions.
+The Network Service YANG models represent an **intent** of the realization of a service. A controller, after an instance of the network service YANG intent has been created, will derive the necessary device-level configurations and apply them to the required devices. However, the implementations reported a set of open issues related to service status. These issues are not solved today and are left to implementation choices and solutions.
 
-* Is the Service running on the Network? (Github issue #5)
-   + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?
-   + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?
-   + How does the system can handle transient errors or partial configuration applications from the model perspective?
-   + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?
-   + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?
-   + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?
-* Operative Status Clarification (Github issue #4)
-   + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network access is another significant operational gap. The status of a VPN service may depend on the status of the underlying VPN nodes and the network access provided to the VPN.
-   + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.
+* Is the Service Running on the Network? (**GitHub Issue #5**)  
+  + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?  
+  + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?  
+  + How can the system handle transient errors or partial configuration applications from the model perspective?  
+  + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?  
+  + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?  
+  + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?  
+
+* Operative Status Clarification (**GitHub Issue #4**)  
+  + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network access is another significant operational gap. The status of a VPN service may depend on the status of the underlying VPN nodes and the network access provided to the VPN.  
+  + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.  
+
 
 ## Summary
 

--- a/draft-bg-onions-update-network-service-models.md
+++ b/draft-bg-onions-update-network-service-models.md
@@ -85,12 +85,18 @@ Implementations of LxNM models in controllers required new functionalities which
 ### L3NM Enhancements
 
 * BFD parametrization of static routes (GitHub Issue #1)
-  + The L3NM YANG data model allows management of static routes in a VPN. That is, for a particular VPN service, new IPv4 and IPv6 static routes can be added, modified, or deleted. The data model allows specifying whether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route, it will need to decide a particular BFD configuration, typically from a predefined template. Operators require, for different services, the ability to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify intended BFD configuration in the IPv4 and IPv6 static routes, including `required-min-rx-interval` and `multiplier`.
+    + The L3NM YANG data model allows management of static routes in a VPN. That is, for a particular VPN service, new
+      IPv4 and IPv6 static routes can be added, modified, or deleted. The data model allows specifying whether BFD is
+      desired in the static route. Whenever a controller derives the device configuration of the static route, it will
+      need to decide a particular BFD configuration, typically from a predefined template. Operators require, for
+      different services, the ability to customize the main BFD parameters to allow, for example, faster detection for
+      critical services. The new requirement is the ability to specify intended BFD configuration in the IPv4 and IPv6
+      static routes, including `required-min-rx-interval` and `multiplier`.
 
-* Management of VLAN 0 in tagged interfaces (GitHub Issue #2):  
+* Management of VLAN 0 in tagged interfaces (GitHub Issue #2):
   LxNM YANG models have a range defined for CVLAN between 1 and 4094. VLAN 0 should also be supported, as it is used in deployments.
 
-* Missing BGP intended configuration blocks (position against Attachment Circuits) (**GitHub Issue #3**):
+* Missing BGP intended configuration blocks (position against Attachment Circuits) (GitHub Issue #3):
   + There are BGP configuration blocks required to manage BGP-based services which are present in the AC-Model but not in the L3NM:
     - BGP Peer group creation
     - BGP Redistribution rules
@@ -100,10 +106,13 @@ Implementations of LxNM models in controllers required new functionalities which
 * SRv6 support for L3VPN (GitHub Issue #15):
   SRv6-based BGP services, including L3VPN, whose procedures are defined in {{?RFC9252}}.
 
-* Improving Multicast Support:  
-  + For L3VPN with multicast, one implementation reported that Cisco MVPN augmentations were added to include various profiles (IPMSI and SPMSI). There is no YANG module from IETF today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.
+* Improving Multicast Support:
+  + For L3VPN with multicast, one implementation reported that Cisco MVPN augmentations were added to include various
+    profiles (IPMSI and SPMSI). There is no YANG module from IETF today that supports full MVPN/SPMSI/IPMSI under L3NM
+    directly. Standardized profiles are required to be added.
 
-* Extend guidance on how the network models can be used to operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework.
+* Extend guidance on how the network models can be used to operationalize Inter-AS VPN options (A, B, and C as defined
+  in {{?RFC4364}}) using the L3NM framework.
 
 ### L2NM Enhancements
 
@@ -135,11 +144,18 @@ Implementations of LxNM models in controllers required new functionalities which
 The realization of advanced connectivity services requires, in addition to the configurations expressed in LxNM models:
 
 * Definition of Access Control Lists (ACLs) and Prefix Sets:  
-  + Connectivity services often include mechanisms to filter forwarding packets. The LxNM models allow inclusion of a `forwarding-profile-identifier`. A forwarding profile refers to the policies that apply to the forwarding of packets conveyed within a VPN. Such policies may consist, for example, of applying ACLs. However, there is currently no ACL network service model (even though a device-level ACL model exists) that allows manipulation of such ACLs and sets when creating the service.  
-  + ACLs and Prefix sets can be reused among services. Thus, they need to be handled at a network level, regardless of the actual service using them.  
+  + Connectivity services often include mechanisms to filter forwarding packets. The LxNM models allow inclusion of a
+    `forwarding-profile-identifier`. A forwarding profile refers to the policies that apply to the forwarding of
+    packets conveyed within a VPN. Such policies may consist, for example, of applying ACLs. However, there is
+    currently no ACL network service model (even though a device-level ACL model exists) that allows manipulation of
+    such ACLs and sets when creating the service.  
+  + ACLs and Prefix sets can be reused among services. Thus, they need to be handled at a network level, regardless of
+    the actual service using them.  
 
 * Definition of routing policies, including community sets, path sets, etc.:  
-  + Advanced connectivity services require the creation of complex policies. The LxNM models allow indicating which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set of device models which could be used as a base for the network model.
+  + Advanced connectivity services require the creation of complex policies. The LxNM models allow indicating which
+    policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set of
+    device models which could be used as a base for the network model.
 
 * Pre- and post-checks before and after deploying a service in the network.
 
@@ -149,19 +165,31 @@ The realization of advanced connectivity services requires, in addition to the c
 
 ## Status of the Intended Network Service
 
-The Network Service YANG models represent an **intent** of the realization of a service. A controller, after an instance of the network service YANG intent has been created, will derive the necessary device-level configurations and apply them to the required devices. However, the implementations reported a set of open issues related to service status. These issues are not solved today and are left to implementation choices and solutions.
+The Network Service YANG models represent an **intent** of the realization of a service. A controller, after an instance
+of the network service YANG intent has been created, will derive the necessary device-level configurations and apply
+them to the required devices. However, the implementations reported a set of open issues related to service status.
+These issues are not solved today and are left to implementation choices and solutions.
 
 * Is the Service Running on the Network? (GitHub Issue #5)  
-  + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?
-  + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?
+  + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on
+    the network device?
+  + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple
+    acknowledgment?
   + How can the system handle transient errors or partial configuration applications from the model perspective?
   + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?
-  + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?
-  + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?
+  + Does the network element provide any operational state parameters or notifications that indicate whether the
+    configuration is active, pending, or has failed?
+  + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change
+    northbound?
 
 * Operative Status Clarification (GitHub Issue #4)  
-  + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network access is another significant operational gap. The status of a VPN service may depend on the status of the underlying VPN nodes and the network access provided to the VPN.  
-  + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.
+  + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network
+    access is another significant operational gap. The status of a VPN service may depend on the status of the
+    underlying VPN nodes and the network access provided to the VPN.  
+  + To address this gap, IETF should establish clear dependencies and correlations between the various operational
+    statuses. This could involve defining specific criteria for determining the overall status of a VPN service based
+    on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and
+    correlation of status information can provide insights into the health and performance of VPN services.
 
 ## Summary
 

--- a/draft-bg-onions-update-network-service-models.md
+++ b/draft-bg-onions-update-network-service-models.md
@@ -84,50 +84,51 @@ Implementations of LxNM models in controllers required new functionalities which
 
 ### L3NM Enhancements
 
-* BFD parametrization of static routes (**GitHub Issue #1**):  
-  + The L3NM YANG data model allows management of static routes in a VPN. That is, for a particular VPN service, new IPv4 and IPv6 static routes can be added, modified, or deleted. The data model allows specifying whether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route, it will need to decide a particular BFD configuration, typically from a predefined template. Operators require, for different services, the ability to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify intended BFD configuration in the IPv4 and IPv6 static routes, including `required-min-rx-interval` and `multiplier`.  
+* BFD parametrization of static routes (GitHub Issue #1)
+  + The L3NM YANG data model allows management of static routes in a VPN. That is, for a particular VPN service, new IPv4 and IPv6 static routes can be added, modified, or deleted. The data model allows specifying whether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route, it will need to decide a particular BFD configuration, typically from a predefined template. Operators require, for different services, the ability to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify intended BFD configuration in the IPv4 and IPv6 static routes, including `required-min-rx-interval` and `multiplier`.
 
-* Management of VLAN 0 in tagged interfaces (**GitHub Issue #2**):  
-  LxNM YANG models have a range defined for CVLAN between 1 and 4094. VLAN 0 should also be supported, as it is used in deployments.  
+* Management of VLAN 0 in tagged interfaces (GitHub Issue #2):  
+  LxNM YANG models have a range defined for CVLAN between 1 and 4094. VLAN 0 should also be supported, as it is used in deployments.
 
-* Missing BGP intended configuration blocks (position against Attachment Circuits) (**GitHub Issue #3**):  
-  + There are BGP configuration blocks required to manage BGP-based services which are present in the AC-Model but not in the L3NM:  
-    - BGP Peer group creation  
-    - BGP Redistribution rules  
-  + Missing pointer to ACL (also present in **GitHub Issue #3**):  
-    - ACL pointer to attach forwarding filter  
+* Missing BGP intended configuration blocks (position against Attachment Circuits) (**GitHub Issue #3**):
+  + There are BGP configuration blocks required to manage BGP-based services which are present in the AC-Model but not in the L3NM:
+    - BGP Peer group creation
+    - BGP Redistribution rules
+  + Missing pointer to ACL (also present in GitHub Issue #3):
+    - ACL pointer to attach forwarding filter
 
-* SRv6 support for L3VPN (**GitHub Issue #15**):  
-  SRv6-based BGP services, including L3VPN, whose procedures are defined in {{?RFC9252}}.  
+* SRv6 support for L3VPN (GitHub Issue #15):
+  SRv6-based BGP services, including L3VPN, whose procedures are defined in {{?RFC9252}}.
 
 * Improving Multicast Support:  
-  + For L3VPN with multicast, one implementation reported that Cisco MVPN augmentations were added to include various profiles (IPMSI and SPMSI). There is no YANG module from IETF today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.  
+  + For L3VPN with multicast, one implementation reported that Cisco MVPN augmentations were added to include various profiles (IPMSI and SPMSI). There is no YANG module from IETF today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.
 
-* Extend guidance on how the network models can be used to operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework.  
+* Extend guidance on how the network models can be used to operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework.
 
 ### L2NM Enhancements
 
-* EVPN Remote and Local eth-tag (**GitHub Issue #6**)  
+* EVPN Remote and Local eth-tag (GitHub Issue #6)
 
-* Explicitly assign an RD at node level (**GitHub Issue #7**):  
-  + In the model, an RD must always be assigned via profile at service level. It is useful to be able to set an explicit RD directly at node level, overriding the profile value. This way, a common profile can be used for the whole service, with use cases where only the RD changes per node.  
+* Explicitly assign an RD at node level (GitHub Issue #7):
+  + In the model, an RD must always be assigned via profile at service level. It is useful to be able to set an explicit RD directly at node level,
+  overriding the profile value. This way, a common profile can be used for the whole service, with use cases where only the RD changes per node.
 
-* Add support for Flexible Cross-Connect (FXC) Service ({{?RFC9744}}) (**GitHub Issue #8**)  
+* Add support for Flexible Cross-Connect (FXC) Service ({{?RFC9744}}) (GitHub Issue #8)
 
-* Add explanatory text for EVPN multihoming using LAG (**GitHub Issue #9**)  
+* Add explanatory text for EVPN multihoming using LAG (GitHub Issue #9)
 
-* Support for VLAN-lists/VLAN-ranges (**GitHub Issue #10**):  
-  + When defining a Layer 2 service, sometimes multiple VLANs are mapped into a given service. It would be good to support this in the L2NM encapsulation stanza. Examples are as follows:  
+* Support for VLAN-lists/VLAN-ranges (GitHub Issue #10):
+  + When defining a Layer 2 service, sometimes multiple VLANs are mapped into a given service. It would be good to support this in the L2NM encapsulation stanza. Examples are as follows:
     - Typically used in single-tagged scenarios: `vlan-id-list [200 210-219 222 234 240-249];`  
-    - Dual-tagged scenario, with s-vlan=430 and a list of c-vlans: `vlan-tags outer 430 inner-list [200 210-219 222 234 240-249];`  
+    - Dual-tagged scenario, with s-vlan=430 and a list of c-vlans: `vlan-tags outer 430 inner-list [200 210-219 222 234 240-249];`
 
-* SRv6 support for L2VPN (**GitHub Issue #15**)  
+* SRv6 support for L2VPN (GitHub Issue #15)
 
-* Performance monitoring:  
-  + ITU-T Y.1731 performance monitoring in Ethernet-based networks. L2NM itself ({{?RFC9291}}) does not natively include OAM specifics.  
+* Performance monitoring:
+  + ITU-T Y.1731 performance monitoring in Ethernet-based networks. L2NM itself ({{?RFC9291}}) does not natively include OAM specifics.
 
-* Add EVI identifier to differentiate it from VPN-ID (**GitHub Issue #24**):  
-  Each EVI maps to a specific EVPN service (e.g., a Layer 2 VPN bridging a particular VLAN across the EVPN fabric).  
+* Add EVI identifier to differentiate it from VPN-ID (GitHub Issue #24):
+  Each EVI maps to a specific EVPN service (e.g., a Layer 2 VPN bridging a particular VLAN across the EVPN fabric).
 
 ## New Functionalities Required to Fully Support Connectivity Services
 
@@ -138,11 +139,11 @@ The realization of advanced connectivity services requires, in addition to the c
   + ACLs and Prefix sets can be reused among services. Thus, they need to be handled at a network level, regardless of the actual service using them.  
 
 * Definition of routing policies, including community sets, path sets, etc.:  
-  + Advanced connectivity services require the creation of complex policies. The LxNM models allow indicating which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set of device models which could be used as a base for the network model.  
+  + Advanced connectivity services require the creation of complex policies. The LxNM models allow indicating which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set of device models which could be used as a base for the network model.
 
-* Pre- and post-checks before and after deploying a service in the network.  
+* Pre- and post-checks before and after deploying a service in the network.
 
-* Preparation of the interface prior to setting up the service.  
+* Preparation of the interface prior to setting up the service.
 
 ---
 
@@ -150,18 +151,17 @@ The realization of advanced connectivity services requires, in addition to the c
 
 The Network Service YANG models represent an **intent** of the realization of a service. A controller, after an instance of the network service YANG intent has been created, will derive the necessary device-level configurations and apply them to the required devices. However, the implementations reported a set of open issues related to service status. These issues are not solved today and are left to implementation choices and solutions.
 
-* Is the Service Running on the Network? (**GitHub Issue #5**)  
-  + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?  
-  + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?  
-  + How can the system handle transient errors or partial configuration applications from the model perspective?  
-  + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?  
-  + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?  
-  + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?  
+* Is the Service Running on the Network? (GitHub Issue #5)  
+  + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?
+  + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?
+  + How can the system handle transient errors or partial configuration applications from the model perspective?
+  + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?
+  + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?
+  + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?
 
-* Operative Status Clarification (**GitHub Issue #4**)  
+* Operative Status Clarification (GitHub Issue #4)  
   + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network access is another significant operational gap. The status of a VPN service may depend on the status of the underlying VPN nodes and the network access provided to the VPN.  
-  + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.  
-
+  + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.
 
 ## Summary
 


### PR DESCRIPTION
All issue references are now consistent with “GitHub Issue #X”, and punctuation/spelling errors (like asign → assign, nodel leve → node level) are fixed.

“advance” → “advanced” where needed.

Corrected typos (netwrok → network).