### PR TITLE
Editorial review minor

### DIFF
--- a/draft-bg-onions-update-network-service-models.md
+++ b/draft-bg-onions-update-network-service-models.md
@@ -80,14 +80,14 @@ Service and Network YANG data models {{?RFC8199}}{{?RFC8309}} such as the Layer 
 
 ## Enhancements to LxSM and LxNM
 
-Implementations of LxNM models in controllers required new functionalities which were not covered {{!RFC9182}} and {{!RFC9291}} to deploy the missing functions in the Operator services. This section compiles the functions that were reported by those implementations.
+Implementations of LxNM models in controllers required new functionalities which were not covered in {{!RFC9182}} and {{!RFC9291}} to deploy the missing functions in the Operator services. This section compiles the functions that were reported by those implementations.
 
 ### L3NM Enhancements
 
 * BFD parametrization of static routes (Github issue #1):
     +  The L3NM Yang data model allows to manage static routes in a VPN. That is, for a particular VPN service, new Pv4 and IPv6 static routes can be added, modified or deleted. The data model allows to specify whether BFD is desired in the static route. Whenever a controller derives the device configuration of the static route it will need to decide a particular BFD configuration, typically from a pre-defined template. Operators required, for different services, to customize the main BFD parameters to allow, for example, faster detection for critical services. The new requirement is the ability to specify BFD intended configuration in the IPv4 and IPv6 static routes, including a required-min-rx-interval and multiplier.
 * Management of VLAN 0 in tagged interfaces (Github issue #2): LxNM Yang models have a range defined for cvlan between 1 and 4094. VLAN 0 should also be supported and is used in deployments.
-* Missing BGP intended configuration blocks (position against Attachment Circuits) (Github issue #3).
+* Missing BGP intended configuration blocks (in relation to Attachment Circuits) (Github issue #3).
     + There are a set of BGP configuration blocks required to manage BGP based services which are present now in the AC-Model but not in the L3NM:
         - BGP Peer group creation
         - BGP Redistribution rules
@@ -95,15 +95,15 @@ Implementations of LxNM models in controllers required new functionalities which
         - ACL pointer to attach forwarding filter
 * SRv6 support for L3VPN (Github issue #15): SRv6-based BGP services including L3VPN, whose procedures are defined in {{?RFC9252}}
 * Improving Multicast Support:
-     + For L3VPN with multicast, one implementation has reported that Cisco MVPN augmentation were added to include various profiles ( ipmsi and spmsi ) . There is YANG module from IETF as of today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.
-* Extend guidance of how the network models can be used to and operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework.
+     + For L3VPN with multicast, one implementation has reported that Cisco MVPN augmentation were added to include various profiles ( ipmsi and spmsi ) . There is no YANG module from IETF as of today that supports full MVPN/SPMSI/IPMSI under L3NM directly. Standardized profiles are required to be added.
+* Extend guidance of how the network models can be used to/and operationalize Inter-AS VPN options (A, B, and C as defined in {{?RFC4364}}) using the L3NM framework (Github issue #25).
 
 ### L2NM Enhancements
 
 
 * EVPN Remote and Local eth-tag (Github issue #6)
 * Explicitly assign a RD at node level (Github issue #7)
-   + In the model, a RD must be always assigned via profile at service level. It is useful to be able to set a explicit RD directly at node level overriding the value of the profile. This way, a common profile can be used for the whole services for use cases where only RD changes per node.
+   + In the model, a RD must be always assigned via profile at service level. It is useful to be able to set a explicit RD directly at node level overriding the value of the profile. This way, a common profile can be used for all the services for use cases where only RD changes per node.
 
 * Add support for Flexible Cross-Connect (FXC) Service ({{?RFC9744}}) (Github issue #8)
 * Add explanatory text for EVPN multihoming using LAG (Github issue #9)
@@ -125,20 +125,20 @@ The realization of advanced connectivity services requires, in addition to the c
 * Definition of routing policies, including community sets, as path sets, etc:
     + Advanced connectivity services require the creation of complex policies. The LxNM models allows to indicate which policy (or policies) should be used. However, LxNM does not include the definition of policies. There are a set a device models which could be used as a base for the network model.
 * Pre and post checks before and after deploying a service in the network.
-* Preparation of the interface. Prior to setting up .
+* Preparation of the interface. Prior to the application of the entire configuration profile.
 
 ## Status of the Intended Network Service
 
-The Network Service Yang models represents an intent of the realization of service. A controller, after an instance of the network service yang intent has been created, will derive the necessary device level configurations and apply them to the necessary devices. However, the implementations reported a set of open issues which are related to the status. Those issues are not solved today and are left to implementation choices and solutions.
+The Network Service Yang models represent an intent of the realization of service. A controller, after an instance of the network service yang intent has been created, will derive the necessary device level configurations and apply them to the necessary devices. However, the implementations reported a set of open issues which are related to the status. Those issues are not solved today and are left to implementation choices and solutions.
 
 * Is the Service running on the Network? (Github issue #5)
    + How can the northbound system be assured with 100% certainty that a configuration has been successfully installed on the network device?
    + What mechanisms or feedback loops exist to confirm successful configuration deployment beyond simple acknowledgment?
-   + How does the system can handle transient errors or partial configuration applications from the model perspective?
+   + How can the system can handle transient errors or partial configuration applications from the model perspective?
    + Are there specific operational attributes that can be used to reflect the real-time status of the configuration?
    + Does the network element provide any operational state parameters or notifications that indicate whether the configuration is active, pending, or has failed?
    + If a configuration is manually removed via CLI at the network device, is there a mechanism to reflect this change northbound?
-* Operative Status Clarification (Github issue #4)
+* Operational Status Clarification (Github issue #4)
    + Understanding the interrelationships between the operational status of VPN services, VPN nodes, and VPN network access is another significant operational gap. The status of a VPN service may depend on the status of the underlying VPN nodes and the network access provided to the VPN.
    + To address this gap, IETF should establish clear dependencies and correlations between the various operational statuses. This could involve defining specific criteria for determining the overall status of a VPN service based on the status of its constituent VPN nodes and network access components. Moreover, real-time monitoring and correlation of status information can provide insights into the health and performance of VPN services.
 


### PR DESCRIPTION

All issue references are now consistent with “GitHub Issue #X”
Corrected typos:

asign → assign
nodel leve → node level
“advance” → “advanced”
netwrok → network